### PR TITLE
Enable client-side caching for covers

### DIFF
--- a/src/Web/Controllers/BooksController.cs
+++ b/src/Web/Controllers/BooksController.cs
@@ -13,7 +13,10 @@ namespace Fulgoribus.Luxae.Web.Controllers
             this.bookRepository = bookRepository;
         }
 
-        //[Route("{controller}/{action}/{bookId}")]
+        /// <remarks>
+        /// Tell the browser to cache images for 1 day.
+        /// </remarks>
+        [ResponseCache(Duration = 60 * 24, Location = ResponseCacheLocation.Client)]
         public async Task<IActionResult> Cover(int id)
         {
             var cover = await bookRepository.GetBookCoverAsync(id);


### PR DESCRIPTION
Enable client-side caching for covers.

Do not do server-side caching, as we do not have a good way to expire on either those or an intermediate proxy (which has to be enabled for the response caching middleware to be enabled) presently.

Fixes #17.